### PR TITLE
use the Apache 2 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PHP-X
 
 [![Build Status](https://api.travis-ci.org/swoole/phpx.svg)](https://travis-ci.org/swoole/phpx)
-[![License](https://img.shields.io/badge/license-GPL3.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)
 
 C++ wrapper for Zend API
 

--- a/include/phpx.h
+++ b/include/phpx.h
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/include/phpx_embed.h
+++ b/include/phpx_embed.h
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/array.cc
+++ b/src/array.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/base.cc
+++ b/src/base.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/class.cc
+++ b/src/class.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/exec.cc
+++ b/src/exec.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/extension.cc
+++ b/src/extension.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/function.cc
+++ b/src/function.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/object.cc
+++ b/src/object.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/string.cc
+++ b/src/string.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+

--- a/src/variant.cc
+++ b/src/variant.cc
@@ -2,13 +2,11 @@
   +----------------------------------------------------------------------+
   | PHP-X                                                                |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2016-2017 The Swoole Group                             |
-  +----------------------------------------------------------------------+
-  | This source file is subject to version 3.0 of the GPL license,       |
+  | This source file is subject to version 2.0 of the Apache license,    |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
-  | http://www.gnu.org/licenses/                                         |
-  | If you did not receive a copy of the GPL3.0 license and are unable   |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
   | to obtain it through the world-wide-web, please send a note to       |
   | license@swoole.com so we can mail you a copy immediately.            |
   +----------------------------------------------------------------------+


### PR DESCRIPTION
[A recent commit](https://github.com/deminy/phpx/commit/4cfa1fa54fef75bf3d8cbbf798c8c595f69cde65) made by @matyhtf switched the license to Apache 2 from GPL 3. Additional updates are necessary to make the change consistent across the whole repository.

This pull request is to:

- update the license badge.
- update license headers in source code.